### PR TITLE
bug fix:: StructContainerField.merge()

### DIFF
--- a/common/src/main/java/jp/co/yahoo/dataplatform/schema/design/StructContainerField.java
+++ b/common/src/main/java/jp/co/yahoo/dataplatform/schema/design/StructContainerField.java
@@ -112,7 +112,8 @@ public class StructContainerField implements INamedContainerField {
           childField = newField;
           update( childField );
         }
-        childField.merge( targetChildField );
+        UnionField unionChildField = (UnionField)targetChildField;
+        childField.merge( unionChildField );
       }
       else{
         set( targetChildField );


### PR DESCRIPTION
@koijima to merge StructContainerField, we need cast IField to Union Field

```Java
Error: java.lang.UnsupportedOperationException: target is not UnionContainerField.
        at jp.co.yahoo.dataplatform.schema.design.UnionField.merge(UnionField.java:97)
        at jp.co.yahoo.dataplatform.schema.design.StructContainerField.merge(StructContainerField.java:115)
```